### PR TITLE
style-fix: space between social icons in footer

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -830,7 +830,11 @@ footer p,
   margin: 0 12px;
 }
 
-.social .social-icon {
+.social {
+  display: flex;
+}
+
+.social a {
   margin-right: 15px;
 }
 

--- a/index.html
+++ b/index.html
@@ -270,10 +270,10 @@
         </p>
         <div class="social">
           <a href="https://www.linkedin.com/in/tinuolaawopetu/" target="_blank">
-            <i class="fab fa-linkedin-in fa-lg social-icon"></i>
+            <i class="fab fa-linkedin-in fa-lg"></i>
           </a>
           <a href="https://github.com/tinuola" target="_blank">
-            <i class="fab fa-github fa-lg social-icon"></i>
+            <i class="fab fa-github fa-lg"></i>
           </a>
         </div>
       </div>
@@ -282,7 +282,7 @@
           <a href="https://thenounproject.com/unlimiticon/" target="_blank">Unlimiticon</a> from Noun Project</p>
         <p>Hero Image by
           <a href="https://unsplash.com/@chrisknight" target="_blank">Chris Knight</a> from Unsplash</p>
-        <p>WTFDummy Text from
+        <p>Dummy Text from
           <a href="https://tinuola.github.io/ferengi-ipsum/" target="_blank">Ferengi Ipsum</a>
         </p>
       </div>


### PR DESCRIPTION
Add display:flex to remove linked blank space after github icon.
Updating text of Ferengi ipsum attribution